### PR TITLE
Improved error handling

### DIFF
--- a/watchid-pam-extension.swift
+++ b/watchid-pam-extension.swift
@@ -36,7 +36,9 @@ public func pam_sm_authenticate(pamh: pam_handler_t, flags: Int, argc: Int, argv
         defer { semaphore.signal() }
 
         if let error = error {
-            fputs("\(error.localizedDescription)\n", stderr)
+            fputs("\(error.localizedDescription)\n", stderr)			
+            result = PAM_IGNORE
+            return
         }
 
         result = success ? PAM_SUCCESS : PAM_AUTH_ERR


### PR DESCRIPTION
With the current implementation, the plugin will just print a message in Terminal, but won't tell the auth mechanism to ignore it, which can cause sudo to fail completely.

This fixes it by returning `PAM_IGNORE` in case of errors, which makes it fallback to password auth in case the Watch mechanism fails.

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/67184/65461006-1c347e00-de21-11e9-84da-644d7e58a427.png">

