### PR TITLE
Add support for Apple Silicon and Big Sur

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
 VERSION = 2
-LIBRARY_NAME = pam_watchid.so
+LIBRARY_PREFIX = pam_watchid
+LIBRARY_NAME = $(LIBRARY_PREFIX).so
 DESTINATION = /usr/local/lib/pam
-TARGET = x86_64-apple-macosx10.15
+TARGET = apple-darwin20.1.0
 
 all:
-	swiftc watchid-pam-extension.swift -o $(LIBRARY_NAME) -target $(TARGET) -emit-library
+	swiftc watchid-pam-extension.swift -o $(LIBRARY_PREFIX)_x86_64.so -target x86_64-$(TARGET) -emit-library
+	swiftc watchid-pam-extension.swift -o $(LIBRARY_PREFIX)_arm64.so -target arm64-$(TARGET) -emit-library
+	lipo -create $(LIBRARY_PREFIX)_arm64.so $(LIBRARY_PREFIX)_x86_64.so -output $(LIBRARY_NAME)
 
 install: all
 	mkdir -p $(DESTINATION)
-	cp $(LIBRARY_NAME) $(DESTINATION)/$(LIBRARY_NAME).$(VERSION)
-	chmod 444 $(DESTINATION)/$(LIBRARY_NAME).$(VERSION)
-	chown root:wheel $(DESTINATION)/$(LIBRARY_NAME).$(VERSION)
+	install -o root -g wheel -m 444 $(LIBRARY_NAME) $(DESTINATION)/$(LIBRARY_NAME).$(VERSION)


### PR DESCRIPTION
Partly taken from upstream in https://github.com/Reflejo/pam-touchID/pull/18.

It's necessary to create a universal binary to avoid the following error when a program running in Rosetta invokes sudo:

```
sudo: unable to initialize PAM: No such file or directory
```

Fixes #7.