### PR TITLE
Remove hard-coded target and optimize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 VERSION = 2
 LIBRARY_NAME = pam_watchid.so
 DESTINATION = /usr/local/lib/pam
-TARGET = x86_64-apple-macosx10.15
+TARGET = $(shell clang -dumpmachine)
 
 all:
-	swiftc watchid-pam-extension.swift -o $(LIBRARY_NAME) -target $(TARGET) -emit-library
+	swiftc watchid-pam-extension.swift -O -Ounchecked -gnone -o $(LIBRARY_NAME) -target $(TARGET) -emit-library
 
 install: all
 	mkdir -p $(DESTINATION)


### PR DESCRIPTION
Detect compile target based on `clang -dumpmachine` result.

Closes #15 and supersedes #20 (partially, it also contains an update to the `install` target).
Resolves #7, resolves #14, resolves #16, and resolves #17. (Why github?)